### PR TITLE
feat: TotoList reusable component

### DIFF
--- a/docs/specs/toto-list.md
+++ b/docs/specs/toto-list.md
@@ -1,0 +1,89 @@
+# Spec: TotoList Component
+
+## Objective
+
+Build a reusable `TotoList` React component for the `toto-react` library. The component renders a vertical list of items, each with a leading icon, a primary title, and an optional subtitle. It also supports a `loading` state that shows 3 animated placeholder rows.
+
+**Who uses it**: Any consumer app in the Toto ecosystem (starting with `tome`'s sources page).  
+**Success**: The `tome` sources page can be fully migrated to use `TotoList` with identical visual output and the loading animation matches the `RoundButton` loading circle.
+
+---
+
+## Core Logic
+
+### Component API
+
+```ts
+interface TotoListItem {
+  id: string;
+  icon: {
+    src: string;   // SVG path (passed to MaskedSvgIcon)
+    alt: string;
+    color?: string; // Tailwind bg-* class, default: "bg-cyan-800"
+  };
+  title: string;
+  subtitle?: string;
+  onClick: () => void;
+}
+
+interface TotoListProps {
+  items?: TotoListItem[];
+  loading?: boolean;
+}
+```
+
+### Row Layout
+
+Each row (`TotoListItem`) renders as:
+```
+[ icon circle ] | Title (bold, truncated)
+                | Subtitle (muted, small)
+```
+- Icon container: `rounded-full border border-cyan-800 p-2`
+- Icon: `MaskedSvgIcon` — `w-5 h-5`, color from `item.icon.color` (default `bg-cyan-800`)
+- Title: `text-sm font-medium truncate`
+- Subtitle: `text-xs text-muted-foreground`
+- Row: `flex items-center gap-3`, press scale animation (`scale(0.98)` on mouse/touch down)
+
+### Loading State
+
+When `loading={true}`, renders **exactly 3** placeholder rows. Each row:
+- **Icon area**: same animated SVG stroke circle as `RoundButton`'s loading animation (`fillCircle` keyframe), rendered in a `rounded-full border border-cyan-800 p-2 w-9 h-9` container
+- **Title shimmer**: `h-4 rounded-md` block with shimmer gradient animation, varying widths (`w-10/12`, `w-8/12`, `w-7/12`)
+- **Subtitle shimmer**: `h-3 rounded-md mt-2` block, one size smaller/shorter
+
+### Shimmer Animation (Bundled)
+
+The shimmer CSS is **not** assumed to exist in the consumer's stylesheet. The component injects it inline via a `<style>` tag:
+
+```css
+@keyframes toto-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.toto-shimmer {
+  background: linear-gradient(90deg, #26767f 0%, #1f6c75 50%, #18646e 100%);
+  background-size: 200% 100%;
+  animation: toto-shimmer 1.5s ease-in-out infinite;
+}
+```
+
+Uses a namespaced class (`toto-shimmer`) to avoid collisions with consumer CSS.
+
+### Loading Circle Animation
+
+Reuses the exact `fillCircle` SVG animation from `RoundButton`:
+- `<svg viewBox="0 0 32 32">` with a `<circle cx="16" cy="16" r="15">`
+- Stroke: `#0891b2`, strokeWidth: `1`
+- `@keyframes fillCircle` cycling `stroke-dashoffset` from full → 0 → negative full over 2s
+
+---
+
+## Out of Scope
+
+- Custom row rendering (no `renderItem` prop)
+- Pagination or infinite scroll
+- Empty state rendering (consumer handles empty state outside the component)
+- Error state rendering
+- Removing `SourcesListSkeleton` from `tome` (that's Task 2 / issue tome#241)
+- Migrating any page other than the sources page to `TotoList`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toto-react",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toto-react",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/speech": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toto-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Shared React component library for the Toto PWA ecosystem",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/components/TotoList.tsx
+++ b/src/components/TotoList.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import React, { useState } from 'react';
+import { MaskedSvgIcon } from './MaskedSvgIcon';
+
+export interface TotoListItem {
+    id: string;
+    icon: {
+        src: string;
+        alt: string;
+        color?: string;
+    };
+    title: string;
+    subtitle?: string;
+    onClick: () => void;
+}
+
+export interface TotoListProps {
+    items?: TotoListItem[];
+    loading?: boolean;
+}
+
+const LOADING_ROW_WIDTHS: Array<{ title: string; subtitle: string }> = [
+    { title: 'w-10/12', subtitle: 'w-7/12' },
+    { title: 'w-8/12',  subtitle: 'w-9/12' },
+    { title: 'w-7/12',  subtitle: 'w-6/12' },
+];
+
+const ANIMATED_CIRCLE_R = 15;
+const CIRCLE_DASH = Math.PI * 2 * ANIMATED_CIRCLE_R;
+
+const SHIMMER_STYLE = `
+@keyframes toto-shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+.toto-shimmer {
+    background: linear-gradient(90deg, #26767f 0%, #1f6c75 50%, #18646e 100%);
+    background-size: 200% 100%;
+    animation: toto-shimmer 1.5s ease-in-out infinite;
+}
+@keyframes toto-fill-circle {
+    0%   { stroke-dashoffset:  ${CIRCLE_DASH}; }
+    50%  { stroke-dashoffset:  0; }
+    100% { stroke-dashoffset: -${CIRCLE_DASH}; }
+}
+`;
+
+function LoadingCircle() {
+    return (
+        <div className="relative flex items-center justify-center rounded-full border border-cyan-800 p-2 w-9 h-9 flex-shrink-0">
+            <svg
+                className="absolute inset-0 w-full h-full"
+                viewBox="0 0 36 36"
+                fill="none"
+            >
+                <circle
+                    cx="18"
+                    cy="18"
+                    r={ANIMATED_CIRCLE_R}
+                    stroke="#0891b2"
+                    strokeWidth="1.5"
+                    strokeDasharray={CIRCLE_DASH}
+                    strokeDashoffset={0}
+                    strokeLinecap="round"
+                    style={{ animation: 'toto-fill-circle 2s linear infinite' }}
+                />
+            </svg>
+        </div>
+    );
+}
+
+function LoadingRow({ widths }: { widths: { title: string; subtitle: string } }) {
+    return (
+        <div className="flex items-center gap-3 py-1">
+            <LoadingCircle />
+            <div className="flex flex-col flex-1 min-w-0 gap-1.5">
+                <div className={`h-4 rounded-md toto-shimmer ${widths.title}`} />
+                <div className={`h-3 rounded-md toto-shimmer ${widths.subtitle}`} />
+            </div>
+        </div>
+    );
+}
+
+function ItemRow({ item }: { item: TotoListItem }) {
+    const [pressed, setPressed] = useState(false);
+
+    return (
+        <div
+            className="flex items-center gap-3 text-left hover:bg-accent transition-colors duration-100"
+            style={{ transform: pressed ? 'scale(0.98)' : 'scale(1)', transition: 'transform 100ms' }}
+            onClick={item.onClick}
+            onMouseDown={() => setPressed(true)}
+            onMouseUp={() => setPressed(false)}
+            onMouseLeave={() => setPressed(false)}
+            onTouchStart={() => setPressed(true)}
+            onTouchEnd={() => setPressed(false)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && item.onClick()}
+        >
+            <div className="rounded-full border border-cyan-800 p-2 flex items-center justify-center flex-shrink-0">
+                <MaskedSvgIcon
+                    src={item.icon.src}
+                    alt={item.icon.alt}
+                    size="w-5 h-5"
+                    color={item.icon.color ?? 'bg-cyan-800'}
+                />
+            </div>
+            <div className="flex flex-col flex-1 min-w-0">
+                <span className="text-sm font-medium truncate">{item.title}</span>
+                {item.subtitle && (
+                    <span className="text-xs text-muted-foreground">{item.subtitle}</span>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export function TotoList({ items = [], loading = false }: TotoListProps) {
+    return (
+        <>
+            <style>{SHIMMER_STYLE}</style>
+            <div className="flex flex-col gap-2">
+                {loading
+                    ? LOADING_ROW_WIDTHS.map((widths, i) => (
+                          <LoadingRow key={i} widths={widths} />
+                      ))
+                    : items.map((item) => (
+                          <ItemRow key={item.id} item={item} />
+                      ))}
+            </div>
+        </>
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,9 @@ export type { ChatInputHandlers } from './components/ChatInput';
 
 export { MaskedSvgIcon } from './components/MaskedSvgIcon';
 
+export { TotoList } from './components/TotoList';
+export type { TotoListItem, TotoListProps } from './components/TotoList';
+
 export { VoiceAgentDock } from './components/VoiceAgentDock';
 export type { VoiceAgentDockProps } from './components/VoiceAgentDock';
 


### PR DESCRIPTION
## Summary
Adds a new `TotoList` reusable component to the library.

## Changes
- `src/components/TotoList.tsx` — new component
- `src/index.ts` — exports `TotoList`, `TotoListItem`, `TotoListProps`
- `docs/specs/toto-list.md` — spec

## Features
- Fixed row structure: icon circle (MaskedSvgIcon) + title + subtitle + onClick
- Press animation (scale 0.98)
- `loading` prop: 3 placeholder rows with animated stroke circle + shimmer text
- Shimmer CSS bundled inline — no consumer CSS dependency

## Closes
Closes #12

## Related
Part of nicolasances/toto#161